### PR TITLE
Added requirement indicator, confirm password, and default for preferences

### DIFF
--- a/react-ui/src/components/pages/SignUp.js
+++ b/react-ui/src/components/pages/SignUp.js
@@ -118,18 +118,23 @@ class SignUp extends React.Component {
     handleSubmit = (e) => {
         e.preventDefault();
         if (this.state.passwordConfirmed) {
+            if (this.state.musicPref.length === 0) this.state.musicPref = "No preference."
+            if (this.state.foodPref.length === 0) this.state.foodPref = "No preference."
+            if (this.state.spacePref.length === 0) this.state.spacePref = "No preference."
+            if (this.state.lightingPref.length === 0) this.state.lightingPref = "No preference."
+            console.log(this.state)
             this.props.userSignUp(this.state)
-        this.setState({ loading: true })
-        // wait one second to check if successfully signed in
-        setTimeout(() => {
-            // if not signed in, show error modal
-            if (!this.props.isSignedIn) {
-                this.setState({
-                    modalToggle: true
-                })
-            }
-            this.setState({ loading: false })
-          }, 1000);
+            this.setState({ loading: true })
+            // wait one second to check if successfully signed in
+            setTimeout(() => {
+                // if not signed in, show error modal
+                if (!this.props.isSignedIn) {
+                    this.setState({
+                        modalToggle: true
+                    })
+                }
+                this.setState({ loading: false })
+            }, 1000);
         } else {
             this.setState({
                 modalToggle: true
@@ -205,6 +210,8 @@ class SignUp extends React.Component {
                         </Form.Group>
                     </Form.Row>
 
+                    <p>Select preferences from the areas below. If you do not have a preference for an area, do not check any boxes.</p>
+
                     <Form.Row>
                         <Form.Group as={Col}>
                             <Form.Label>Music Preference</Form.Label>
@@ -213,7 +220,6 @@ class SignUp extends React.Component {
                             <Form.Check type="checkbox" label="Indie" value="indie" onChange={this.handleMOptions}/>
                             <Form.Check type="checkbox" label="Pop" value="pop" onChange={this.handleMOptions}/>
                             <Form.Check type="checkbox" label="Funky" value="funky" onChange={this.handleMOptions}/>
-                            <Form.Check type="checkbox" label="No Preference" value="nopref" onChange={this.handleMOptions}/>
                         </Form.Group>
                         <Form.Group as={Col}>
                             <Form.Label>Space Preference</Form.Label>
@@ -221,7 +227,6 @@ class SignUp extends React.Component {
                             <Form.Check type="checkbox" label="Couple of People" value="couple" onChange={this.handleSOptions}/>
                             <Form.Check type="checkbox" label="Small Group (<4)" value="smallgroup" onChange={this.handleSOptions}/>
                             <Form.Check type="checkbox" label="Large Group (5+)" value="largegroup" onChange={this.handleSOptions}/>
-                            <Form.Check type="checkbox" label="No Preference" value="nopref" onChange={this.handleSOptions}/>
                         </Form.Group>
                     </Form.Row>
                     <Form.Row>
@@ -230,14 +235,12 @@ class SignUp extends React.Component {
                             <Form.Check type="checkbox" label="Dim Lighting" value="dim" onChange={this.handleLOptions}/>
                             <Form.Check type="checkbox" label="Natural Lighting" value="natural" onChange={this.handleLOptions}/>
                             <Form.Check type="checkbox" label="Bright Lighting" value="bright" onChange={this.handleLOptions}/>
-                            <Form.Check type="checkbox" label="No Preference" value="nopref" onChange={this.handleLOptions}/>
                         </Form.Group>
                         <Form.Group as={Col}>
                             <Form.Label>Food Preference</Form.Label>
                             <Form.Check type="checkbox" label="Small Bites/Bakery" value="smallbites" onChange={this.handleFOptions}/>
                             <Form.Check type="checkbox" label="Full Menu" value="fullmenu" onChange={this.handleFOptions}/>
                             <Form.Check type="checkbox" label="Just Coffee" value="coffee" onChange={this.handleFOptions}/>
-                            <Form.Check type="checkbox" label="No Preference" value="nopref" onChange={this.handleFOptions}/>
                         </Form.Group>
                     </Form.Row>
 

--- a/react-ui/src/components/pages/SignUp.js
+++ b/react-ui/src/components/pages/SignUp.js
@@ -23,6 +23,7 @@ class SignUp extends React.Component {
         spacePref: [],
         lightingPref: [],
         foodPref: [],
+        passwordConfirmed: false,
         modalToggle: false,
         loading: true
     }
@@ -38,6 +39,21 @@ class SignUp extends React.Component {
         this.setState({
             [e.target.id]: e.target.value,
         })
+    }
+
+    handleConfirmPassword = (e) => {
+        if (this.state.password === e.target.value) {
+            this.setState({
+                passwordConfirmed: true,
+            })
+        } else {
+            this.setState({
+                passwordConfirmed: false,
+            })
+        }
+        console.log("IN CONFIRM PASSWORD")
+        console.log(e.target.value)
+        console.log(this.state.passwordConfirmed)
     }
 
     // handles state info that can have multiple options
@@ -101,7 +117,8 @@ class SignUp extends React.Component {
     // handles submit, sending state information to redux store
     handleSubmit = (e) => {
         e.preventDefault();
-        this.props.userSignUp(this.state)
+        if (this.state.passwordConfirmed) {
+            this.props.userSignUp(this.state)
         this.setState({ loading: true })
         // wait one second to check if successfully signed in
         setTimeout(() => {
@@ -113,6 +130,12 @@ class SignUp extends React.Component {
             }
             this.setState({ loading: false })
           }, 1000);
+        } else {
+            this.setState({
+                modalToggle: true
+            })
+        }
+        
     }
 
     // for handling closing of modal
@@ -140,38 +163,44 @@ class SignUp extends React.Component {
             <div>
                 <Form id="form" onSubmit={this.handleSubmit}>
                     <h1>sign up</h1>
+                    <p>Fields marked with (*) are required.</p>
                     <hr></hr>
                     <Form.Group >
                         <Form.Row>
                             <Col>
-                                <Form.Label>First Name</Form.Label>
+                                <Form.Label>First Name*</Form.Label>
                                 <Form.Control required onChange={this.handleChange} id="fName" />
                             </Col>
                             <Col>
-                                <Form.Label>Last Name</Form.Label>
+                                <Form.Label>Last Name*</Form.Label>
                                 <Form.Control required onChange={this.handleChange} id="lName"  />
                             </Col>
                         </Form.Row>
                     </Form.Group>
                     
                     <Form.Group >
-                        <Form.Label>Email</Form.Label>
+                        <Form.Label>Email*</Form.Label>
                         <Form.Control required onChange={this.handleChange} id="email" type="email"  />
                     </Form.Group>
 
                     <Form.Group>
-                        <Form.Label>Password</Form.Label>
+                        <Form.Label>Password*</Form.Label>
                         <Form.Control required onChange={this.handleChange} id="password" type="password"/>
+                    </Form.Group>
+
+                    <Form.Group>
+                        <Form.Label>Confirm Password *</Form.Label>
+                        <Form.Control required onChange={this.handleConfirmPassword} id="passwordConfirm" type="password"/>
                     </Form.Group>
 
                     <Form.Row>
                         <Form.Group as={Col}>
-                            <Form.Label>State</Form.Label>
+                            <Form.Label>State*</Form.Label>
                             <Form.Control required onChange={this.handleChange} id="state"/>
                         </Form.Group>
                         
                         <Form.Group as={Col} >
-                            <Form.Label>Zip Code</Form.Label>
+                            <Form.Label>Zip Code*</Form.Label>
                             <Form.Control required onChange={this.handleChange} id="zipcode" />
                         </Form.Group>
                     </Form.Row>
@@ -227,7 +256,7 @@ class SignUp extends React.Component {
                         <Modal.Title>Sorry, there was an error.</Modal.Title>
                     </Modal.Header>
                     {/* displays appropriate error message */}
-                    <Modal.Body>{this.props.errorMsg.toString()}</Modal.Body>
+                    <Modal.Body>{this.state.passwordConfirmed ? this.props.errorMsg.toString() : "Passwords do not match."}</Modal.Body>
                     <Modal.Footer>
                     <Button variant="secondary" onClick={this.handleClose}>
                         Close

--- a/react-ui/src/components/pages/SignUp.js
+++ b/react-ui/src/components/pages/SignUp.js
@@ -118,10 +118,6 @@ class SignUp extends React.Component {
     handleSubmit = (e) => {
         e.preventDefault();
         if (this.state.passwordConfirmed) {
-            if (this.state.musicPref.length === 0) this.state.musicPref = "No preference."
-            if (this.state.foodPref.length === 0) this.state.foodPref = "No preference."
-            if (this.state.spacePref.length === 0) this.state.spacePref = "No preference."
-            if (this.state.lightingPref.length === 0) this.state.lightingPref = "No preference."
             console.log(this.state)
             this.props.userSignUp(this.state)
             this.setState({ loading: true })


### PR DESCRIPTION
Added asterisks to indicate if a field is required or not
<img width="922" alt="Screen Shot 2020-10-25 at 11 19 47 AM" src="https://user-images.githubusercontent.com/16119631/97112753-11978880-16b4-11eb-8ca4-0c035f19395a.png">

Client-side confirm password check
<img width="855" alt="Screen Shot 2020-10-25 at 11 20 12 AM" src="https://user-images.githubusercontent.com/16119631/97112761-178d6980-16b4-11eb-989d-6eefb494d761.png">

Removed "No preference" for preference; instead defaults to no preference if no checkbox is selected, returns the following (for back end reference):
<img width="766" alt="Screen Shot 2020-10-25 at 11 16 02 AM" src="https://user-images.githubusercontent.com/16119631/97112737-ed3bac00-16b3-11eb-849b-4abc903e3fe4.png">
