### PR TITLE
removed call to proxy cors-anywhere server when fetching popular times

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -131,6 +131,14 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
+    "axios": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.0.tgz",
+      "integrity": "sha512-fmkJBknJKoZwem3/IKSSLpkdNXZeBu5Q7GA/aRsr2btgrptmSCxi2oFjZHqGdK9DoTil9PIHlPIZw2EcRJXRvw==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -616,6 +624,11 @@
         "statuses": "~1.5.0",
         "unpipe": "~1.0.0"
       }
+    },
+    "follow-redirects": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
+      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
     },
     "forwarded": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@fortawesome/free-regular-svg-icons": "^5.15.1",
     "@fortawesome/free-solid-svg-icons": "^5.15.1",
     "@fortawesome/react-fontawesome": "^0.1.12",
+    "axios": "^0.21.0",
     "body-parser": "^1.19.0",
     "cluster": "^0.7.7",
     "cors": "^2.8.5",

--- a/react-ui/src/services/popularTimes.js
+++ b/react-ui/src/services/popularTimes.js
@@ -1,79 +1,14 @@
 // adapted from source code at https://github.com/rak-trzustki/busy-hours/blob/master/src/index.js
 
 const popularTimes = async (placeUrl) => {
-    if (!(placeUrl)) {
-        return { status: 'error', message: 'Place URL missing' };
-    }
+    console.log(placeUrl)
+    let resp = await fetch('/poptimes?placeUrl=' + placeUrl);
+    let json = await resp.json();
 
-    try {
-        const html = await fetch_html(placeUrl);
-        return Object.assign(process_html(html));
-    } catch (err) {
-        return { status: 'error', message: 'Error: ' + err.message || err };
-    }
-};
-
-const format_output = array => {
     return {
-        hour: array[0],
-        percentage: array[1]
-    }
-};
-
-const extract_data = async html => {
-
-    let str = ['APP_INITIALIZATION_STATE=', 'window.APP_FLAGS']
-    let script = html.substring(html.lastIndexOf(str[0]) + str[0].length, html.lastIndexOf(str[1]));
-
-    let first = eval(script);
-    let second = eval(first[3][6].replace(")]}'", ""));
-
-    return second[6][84];
-};
-
-const process_html = async html => {
-    const popular_times = await extract_data(html);
-
-    if (!popular_times) {
-        return { status: 'error', message: 'Place has no popular hours' };
-    }
-
-    const data = { status: 'ok' };
-    const weekdays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
-
-    data.week = Array.from(Array(7).keys()).map(index => {
-        let hours = [];
-        if (popular_times[0][index] && popular_times[0][index][1]) {
-            hours = Array.from(popular_times[0][index][1]).map(array => format_output(array));
-        }
-        return {
-            day: weekdays[index],
-            hours: hours
-        };
-    });
-    const crowded_now = popular_times[7];
-
-    if (crowded_now !== undefined) {
-        data.now = format_output(crowded_now);
-    }
-    return data;
-
-};
-
-const fetch_html = async (url) => {
-    try {
-        // some kind soul has built this server that lets us bypass the no 
-        // Access-Control-Allow-Origin error recieved from a plain ol' fetch
-        const proxyUrl = "https://cors-anywhere.herokuapp.com/";
-
-        const html = await fetch(proxyUrl + url, {
-            method: 'GET',
-        });
-
-        return html.text();
-    }
-    catch (err) {
-        return { status: 'error', message: 'Invalid url' };
+        status: json.popularTimes ? json.popularTimes.status : json.status,
+        message: json.message,
+        week: json.popularTimes ? json.popularTimes.week : undefined
     }
 };
 

--- a/server/index.js
+++ b/server/index.js
@@ -2,7 +2,7 @@
 
 const express = require('express');
 const path = require('path');
-// const cors = require('cors');
+const cors = require('cors');
 // a logger middleware. morgan will use the 'next' method (passed to api functions) 
 // in order to log api requests in the console without interfering
 const morgan = require('morgan');
@@ -33,11 +33,11 @@ if (!isDev && cluster.isMaster) {
 } else {
     const app = express(); // start the express application which lets us use utility methods, etc.   
 
-    // var corsOptions = {
-    //     origin: "http://localhost:8081"
-    // };
+    var corsOptions = {
+        origin: "http://localhost:8081"
+    };
     
-    // app.use(cors(corsOptions));
+    app.use(cors(corsOptions));
     app.use(morgan('dev'));
     app.use(bodyParser.json());
     app.use(bodyParser.urlencoded({extended: true}));
@@ -63,6 +63,9 @@ if (!isDev && cluster.isMaster) {
     // const customRoutes = require('./routes/custom');
     // .use() sets up some middleware. an incoming request (and its body) must go through .use() 
     // app.use('/api/custom', customRoutes);
+
+    const poptimesRoutes = require('./routes/poptimes');
+    app.use('/poptimes', poptimesRoutes);
 
     // All remaining requests return the React app, so it can handle routing.
     app.get('*', function (req, res) {

--- a/server/routes/poptimes.js
+++ b/server/routes/poptimes.js
@@ -1,0 +1,99 @@
+const express = require('express');
+const axios = require('axios')
+const router = express.Router();
+
+// Acts as a proxy server to make cors requests from anywhere. A clone
+// of the service found at https://cors-anywhere.herokuapp.com/
+// Source code from https://github.com/Rob--W/cors-anywhere/
+
+router.get('/', async (req, res) => {
+    // adapted from source code at https://github.com/rak-trzustki/busy-hours/blob/master/src/index.js
+
+    const resError = (err) => {
+        return res.status(500).json({
+            status: 'error', 
+            message: 'Error: ' + err
+        });
+    }
+
+    let placeUrl = req.query.placeUrl;
+
+    try {
+        if (!placeUrl) {
+            resError('Place URL missing');
+        } else {
+            const html = await fetch_html(placeUrl);
+
+            if (html.status === 'error') {
+                resError(html.message);
+            } else {
+                let popularTimes = process_html(html);
+
+                res.status(200).json({
+                    status: 'ok',
+                    message: `Popular times returned from ${placeUrl}`,
+                    popularTimes: await popularTimes //await popularTimes
+                });
+            }
+        }
+    } catch (err) {
+        resError(err);
+    }
+});
+
+const format_output = array => {
+    return {
+        hour: array[0],
+        percentage: array[1]
+    }
+};
+
+const extract_data = async html => {
+    let str = ['APP_INITIALIZATION_STATE=', 'window.APP_FLAGS']
+    let script = html.substring(html.lastIndexOf(str[0]) + str[0].length, html.lastIndexOf(str[1]));
+
+    let first = eval(script);
+    let second = eval(first[3][6].replace(")]}'", ""));
+
+    return second[6][84];
+};
+
+const process_html = async html => {
+    const popular_times = await extract_data(html);
+
+    if (!popular_times) {
+        return { status: 'error', message: 'Place has no popular hours' };
+    }
+
+    const data = { status: 'ok' };
+    const weekdays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+    data.week = Array.from(Array(7).keys()).map(index => {
+        let hours = [];
+        if (popular_times[0][index] && popular_times[0][index][1]) {
+            hours = Array.from(popular_times[0][index][1]).map(array => format_output(array));
+        }
+        return {
+            day: weekdays[index],
+            hours: hours
+        };
+    });
+    const crowded_now = popular_times[7];
+
+    if (crowded_now !== undefined) {
+        data.now = format_output(crowded_now);
+    }
+    return data;
+};
+
+const fetch_html = async (url) => {
+    try {
+        let html = await axios.get(url);
+        return html.data || html.text();
+    }
+    catch (err) {
+        return { status: 'error', message: 'Invalid url' };
+    }
+};
+
+module.exports = router;


### PR DESCRIPTION
- popular times are now fetched from the backend using a new /poptimes route (takes query parameter `placeUrl`). removes need for using the cors-anywhere proxy server
- no changes are needed on the front end 

**VERY IMPORTANT PLEASE READ**: To test locally, we now need to start the backend server in addition to the react app. Please use these steps:

1. cd into root project folder StudySpotsFrontEnd
2. enter npm install  to install the new packages used in the server. this must be done in the root folder in addition to react-ui
3. enter `npm test` in the terminal. this starts the backend server which will handle requests to localhost:5000/poptimes
4. open a new terminal (do not close the first one)
5. cd into react-ui
6. enter `npm start` in the terminal to start the react app as usual